### PR TITLE
Emitting useful socket.io config on PUT domain

### DIFF
--- a/src/ably/AblyCloneFactory.ts
+++ b/src/ably/AblyCloneFactory.ts
@@ -30,7 +30,7 @@ export class AblyCloneFactory extends CloneFactory {
       return ablyModule.AblyRemotes;
   }
 
-  reusableConfig(config: AblyGatewayConfig): BaseGatewayConfig {
+  async reusableConfig(config: AblyGatewayConfig): Promise<BaseGatewayConfig> {
     const { ably } = config;
     return Env.mergeConfig(super.reusableConfig(config), { ably }, {
       ably: { key: false, apiKey: false } // Remove Ably secrets

--- a/src/lib/BaseGateway.ts
+++ b/src/lib/BaseGateway.ts
@@ -13,7 +13,7 @@ export interface BaseGatewayConfig extends MeldConfig, AuthKeyConfig {
    * Gateway identifier, may be a domain name or a URL
    * @see resolveGateway
    */
-  gateway: string | URL | false;
+  gateway: string | URL;
   /** The user; undefined if this is a service */
   user?: string;
   /** Allow any other keys for config */

--- a/src/lib/CloneFactory.ts
+++ b/src/lib/CloneFactory.ts
@@ -46,7 +46,7 @@ export abstract class CloneFactory {
    * @returns the subset of configuration that can be re-used by other engines
    * cloning the same domains
    */
-  reusableConfig(config: BaseGatewayConfig): Partial<BaseGatewayConfig> {
+  async reusableConfig(config: BaseGatewayConfig): Promise<Partial<BaseGatewayConfig>> {
     const { networkTimeout, maxOperationSize, logLevel } = config;
     return { networkTimeout, maxOperationSize, logLevel };
   }

--- a/src/server/Gateway.ts
+++ b/src/server/Gateway.ts
@@ -270,7 +270,7 @@ export class Gateway extends BaseGateway implements AccountContext {
     // Return the config required for a new clone, using some of our config
     return Object.assign({
       '@domain': tsDomain, genesis: false // Definitely not genesis
-    }, this.cloneFactory.reusableConfig(this.config));
+    }, await this.cloneFactory.reusableConfig(this.config));
   }
 
   async isGenesis(state: MeldReadState, id: AccountOwnedId) {

--- a/src/socket.io/IoCloneFactory.ts
+++ b/src/socket.io/IoCloneFactory.ts
@@ -9,30 +9,16 @@ export class IoCloneFactory extends CloneFactory {
    * Set if the socket.io server address is known
    * @type {string}
    */
-  private address: string;
+  private address?: string;
 
   async clone(
     config: BaseGatewayConfig,
     dataDir: string,
     principal?: GatewayPrincipal
   ) {
-    const { root } = resolveGateway(this.address ?? config.gateway);
-    const uri = (await root).toString();
-    LOG.info('IO connecting to', uri, 'for', config['@domain']);
-    return super.clone(Env.mergeConfig(config, {
-      // When using Socket.io, the authorisation key is sent to the server
-      // See https://socket.io/docs/v4/middlewares/#sending-credentials
-      io: {
-        uri: uri,
-        opts: {
-          auth: {
-            ...config.auth,
-            // The user may be undefined, if this is a Gateway
-            user: config.user
-          }
-        }
-      }
-    }), dataDir, principal);
+    const ioConfig = await this.ioConfig(config);
+    LOG.info('IO connecting to', ioConfig.io.uri, 'for', config['@domain']);
+    return super.clone(Env.mergeConfig(config, ioConfig), dataDir, principal);
   }
 
   initialise(address: string) {
@@ -41,5 +27,30 @@ export class IoCloneFactory extends CloneFactory {
 
   remotes(config: BaseGatewayConfig) {
     return IoRemotes;
+  }
+
+  async reusableConfig(config: BaseGatewayConfig): Promise<Partial<BaseGatewayConfig>> {
+    return Env.mergeConfig(super.reusableConfig(config),
+      await this.ioConfig(config, true));
+  }
+
+  private async ioConfig(config: BaseGatewayConfig, reusable = false) {
+    // Reusable config always doles out public gateway address
+    const uri = !reusable && this.address ? this.address :
+      (await resolveGateway(config.gateway.toString()).root).toString();
+    return {
+      // When using Socket.io, the authorisation key is sent to the server
+      // See https://socket.io/docs/v4/middlewares/#sending-credentials
+      io: {
+        uri: uri,
+        opts: {
+          auth: {
+            key: reusable ? '' : config.auth.key,
+            // The user may be undefined, if this is a Gateway
+            user: reusable ? '' : config.user
+          }
+        }
+      }
+    };
   }
 }

--- a/test/Gateway.test.ts
+++ b/test/Gateway.test.ts
@@ -26,7 +26,7 @@ describe('Gateway', () => {
       const clone = await meldClone(backend, DeadRemotes, config);
       return [clone, backend];
     });
-    cloneFactory.reusableConfig.mockImplementation(config => {
+    cloneFactory.reusableConfig.mockImplementation(async config => {
       // Random key for testing of reusable config
       const { networkTimeout, maxOperationSize, logLevel, tls } = config;
       return { networkTimeout, maxOperationSize, logLevel, tls };

--- a/test/IoCloneFactory.test.ts
+++ b/test/IoCloneFactory.test.ts
@@ -1,0 +1,17 @@
+import { IoCloneFactory } from '../src/index.js';
+
+describe('Socket.io clone factory', () => {
+  test('reusable config', async () => {
+    const cloneFactory = new IoCloneFactory();
+    await cloneFactory.initialise('localhost:8080');
+    await expect(cloneFactory.reusableConfig({
+      '@id': 'test1', '@domain': 'ex.org', genesis: false,
+      gateway: 'ex.org', auth: { key: 'appid.keyid:secret' }
+    })).resolves.toEqual({
+      io: {
+        uri: 'https://ex.org/', // Uses public gateway
+        opts: { auth: { key: '', user: '' } } // Scrubs secrets
+      }
+    });
+  });
+});


### PR DESCRIPTION
Now domain PUT returns something like:
```json
{
  "@domain": "t1.appid.georges-imac.local",
  "genesis": false,
  "io": {
    "uri": "http://127.0.0.1/",
    "opts": {
      "auth": {
        "key": "",
        "user": ""
      }
    }
  }
}
```